### PR TITLE
Make testpmd image multi-stage

### DIFF
--- a/testpmd/Dockerfile
+++ b/testpmd/Dockerfile
@@ -1,7 +1,8 @@
-FROM quay.io/centos/centos:8
+## Build image
+FROM quay.io/centos/centos:8 as build
 
-ENV DPDK_VER 19.11
-ENV DPDK_DIR /usr/src/dpdk-${DPDK_VER}
+ENV DPDK_VER=19.11
+ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
 ENV RTE_TARGET=x86_64-native-linuxapp-gcc
 ENV RTE_SDK=${DPDK_DIR}
 
@@ -15,29 +16,44 @@ RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
     tar -xpvf /usr/src/dpdk-${DPDK_VER}.tar.xz -C /usr/src && \
     rm -f /usr/src/dpdk-${DPDK_VER}.tar.xz
 
+# Download dependencies
+RUN git clone https://github.com/krsacme/testpmd-as-load-balancer.git $(pwd)/testpmd-as-load-balancer
+
 # Configuration
 RUN sed -i -e 's/EAL_IGB_UIO=y/EAL_IGB_UIO=n/' \
-      -e 's/KNI_KMOD=y/KNI_KMOD=n/' \
-      -e 's/LIBRTE_KNI=y/LIBRTE_KNI=n/' \
-      -e 's/LIBRTE_PMD_KNI=y/LIBRTE_PMD_KNI=n/' $DPDK_DIR/config/common_linux && \
+    -e 's/KNI_KMOD=y/KNI_KMOD=n/' \
+    -e 's/LIBRTE_KNI=y/LIBRTE_KNI=n/' \
+    -e 's/LIBRTE_PMD_KNI=y/LIBRTE_PMD_KNI=n/' $DPDK_DIR/config/common_linux && \
     sed -i 's/\(CONFIG_RTE_LIBRTE_MLX5_PMD=\)n/\1y/g' $DPDK_DIR/config/common_base
 
 # Build it
 RUN cd ${DPDK_DIR} && \
     make install T=${RTE_TARGET} DESTDIR=${RTE_SDK} -j 8
 
-# python required for expand-cpu util
-RUN yum install -y python3 && yum clean all
-
-# DEBUGGING: htop added for toobox debugging
-RUN dnf install -y epel-release
-RUN dnf install -y htop lsof perf && dnf clean all
-
-COPY testpmd-as-load-balancer/v19.11/test-pmd ${DPDK_DIR}/app/test-pmd
-RUN cd ${DPDK_DIR}/app/test-pmd && \
+RUN cp -af $(pwd)testpmd-as-load-balancer/v19.11/test-pmd ${DPDK_DIR}/app/test-pmd && \
+    cd ${DPDK_DIR}/app/test-pmd && \
     make -j 8 && \
     cp testpmd /usr/local/bin
+
+## testpmd image
+FROM quay.io/centos/centos:8
+
+# Required libraries and debugging tools
+RUN dnf install -y \
+    epel-release \
+    libibverbs \
+    logrotate \
+    numactl \
+    python3 \
+    rdma-core \
+    tcpdump \
+    && dnf install -y \
+    htop \
+    lsof \
+    perf \
+    && dnf clean all
 
 # copy testpmd runtime cmdline file
 COPY testpmd-runtime-cmds.txt /root/testpmd-runtime-cmds.txt
 COPY scripts /usr/local/bin
+COPY --from=build /usr/local/bin/testpmd /usr/local/bin/testpmd

--- a/testpmd/Dockerfile
+++ b/testpmd/Dockerfile
@@ -1,5 +1,5 @@
 ## Build image
-FROM quay.io/centos/centos:8 as build
+FROM quay.io/centos/centos:stream8 as build
 
 ENV DPDK_VER=19.11
 ENV DPDK_DIR=/usr/src/dpdk-${DPDK_VER}
@@ -7,9 +7,9 @@ ENV RTE_TARGET=x86_64-native-linuxapp-gcc
 ENV RTE_SDK=${DPDK_DIR}
 
 # Install prerequisite packages
-RUN yum groupinstall -y "Development Tools" && \
-    yum install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
-    yum clean all
+RUN dnf groupinstall -y "Development Tools" && \
+    dnf install --skip-broken -y wget numactl numactl-devel make libibverbs-devel logrotate rdma-core tcpdump && \
+    dnf clean all
 
 # Download the DPDK libraries
 RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz -P /usr/src && \
@@ -36,7 +36,7 @@ RUN cp -af $(pwd)testpmd-as-load-balancer/v19.11/test-pmd ${DPDK_DIR}/app/test-p
     cp testpmd /usr/local/bin
 
 ## testpmd image
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 # Required libraries and debugging tools
 RUN dnf install -y \

--- a/testpmd/Dockerfile
+++ b/testpmd/Dockerfile
@@ -47,10 +47,6 @@ RUN dnf install -y \
     python3 \
     rdma-core \
     tcpdump \
-    && dnf install -y \
-    htop \
-    lsof \
-    perf \
     && dnf clean all
 
 # copy testpmd runtime cmdline file


### PR DESCRIPTION
- Doing multi-stage build
- Reduces the size (and surface) of the final image
- Still uses centos:8

---

Original image is:
```
quay.io/rh-nfv-int/testpmd-container-app-testpmd   v0.2.2          8bb31352d23e  43 hours ago    2.29 GB
```

This change creates:
```
quay.io/tonyskapunk/testpmd-container-app-testpmd  centos8-latest  03a59f6a09c3  21 minutes ago  318 MB
```
