### PR TITLE
Build and push versioned images only on tagged commits

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -2,8 +2,10 @@ name: Quay
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+  workflow_dispatch:
 
 env:
   REGISTRY: quay.io
@@ -17,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@v1.4
+        uses: redhat-actions/podman-login@v1
         with:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
Instead of pushing on merges to master, only build when explicitly tagged
Use major version on GHA instead of major.minor.