### PR TITLE
Add GitHub Action to build images on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,40 @@
+name: Pull Request image
+
+on:
+  pull_request:
+    branches:
+      - master
+
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: "Force building images from a branch"
+        required: true
+        default: false
+        type: boolean
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  pull-request-image:
+    # Build only when the PR comes from a branch in the same repo or forced
+    if: github.repository == github.event.pull_request.head.repo.full_name || inputs.force_build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+
+      - name: Build and Push the images
+        run: |
+          ORG=${GITHUB_REPOSITORY%/*}
+          SHA=$(git rev-parse --short HEAD)
+          make all ORG=${ORG} TAG=${SHA}


### PR DESCRIPTION
Building images on PRs will help to ease the testing of such images
The images pushed use the commit hash as the tag.

Only PRs coming from the same repo will trigger the build+push of images.

It's possible to manually force a build+push of images in a branch (without a PR) through a dispatch workflow using a branch in the repo.

### Testing

* This PR should **NOT** build an image, should skip the action job. This is because the _head repo_ is not the same as the _base repo_ (this is coming from a forked repository) - This is to prevent incoming PRs from unknown repos to build images using our secrets.
* This other PR (https://github.com/tonyskapunk/testpmd-container-app/pull/4) **build+push** the images as the _head repo_ is the **same** as the _base one_ here is the [action job](https://github.com/tonyskapunk/testpmd-container-app/actions/runs/4328170790/jobs/7557580566). This is the behavior that we will expect when a PR is created from the same repo.

Please note that this does not prevent others from opening PRs, it will simply not build images in such cases.

If an image wants to be created without a PR it is possible through a workflow dispatch, the same restriction applies, the commit must be in a branch in this repository.

